### PR TITLE
Added deploy instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Running `npm test` will run unit tests in `test/*.test.js`. Use `npm test -- --c
  - `npm test`
  - `npm version {patch|minor|major}`
  - `git push --follow-tags`
- - `aws s3 cp --acl public-read mapbox-gl-rtl-text.js.min s3://mapbox-gl-js/plugins/mapbox-gl-rtl-text/$(node --print --eval "require('./package.json').version")/mapbox-gl-rtl-text.js`
+ - `aws s3 cp --acl public-read mapbox-gl-rtl-text.js.min s3://mapbox-gl-js/plugins/mapbox-gl-rtl-text/v$(node --print --eval "require('./package.json').version")/mapbox-gl-rtl-text.js`

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ Running `build.sh` will:
 Build process only tested on MacOS 10.12.
 
 Running `npm test` will run unit tests in `test/*.test.js`. Use `npm test -- --cov` to generate code coverage stats.
+
+## Deploying mapbox-gl-rtl-text
+
+ - `./build.sh`
+ - `npm test`
+ - `npm version {patch|minor|major}`
+ - `git push --follow-tags`
+ - `aws s3 cp --acl public-read mapbox-gl-rtl-text.js.min s3://mapbox-gl-js/plugins/mapbox-gl-rtl-text/$(node --print --eval "require('./package.json').version")/mapbox-gl-rtl-text.js`


### PR DESCRIPTION
Adds instructions for deployment of new releases to s3. This frees us from having to do deployment within the GL JS repository.

Related to mapbox/mapbox-gl-js#4305