### PR TITLE
Added UMD wrapper for module version

### DIFF
--- a/src/module-postfix.js
+++ b/src/module-postfix.js
@@ -1,3 +1,5 @@
-module.exports.applyArabicShaping = applyArabicShaping;
-module.exports.processBidirectionalText = processBidirectionalText;
-module.exports.processStyledBidirectionalText = processStyledBidirectionalText;
+exports.applyArabicShaping = applyArabicShaping;
+exports.processBidirectionalText = processBidirectionalText;
+exports.processStyledBidirectionalText = processStyledBidirectionalText;
+
+});

--- a/src/module-prefix.js
+++ b/src/module-prefix.js
@@ -1,3 +1,12 @@
+(function (global, factory) {
+  if (typeof exports === 'object' && typeof module !== 'undefined') {
+    factory(module.exports)
+  } else if (typeof define === 'function' && define.amd) {
+    define(factory);
+  } else {
+    factory(global);
+  }
+}) (this, function (exports) {
 var Module = {
   TOTAL_MEMORY: 8*1024*1024,
   TOTAL_STACK: 2*1024*1024 ,

--- a/src/plugin-postfix.js
+++ b/src/plugin-postfix.js
@@ -1,1 +1,3 @@
 self.registerRTLTextPlugin({'applyArabicShaping': applyArabicShaping, 'processBidirectionalText': processBidirectionalText, 'processStyledBidirectionalText': processStyledBidirectionalText});
+
+});


### PR DESCRIPTION
We are trying to use your wonderful module (thanks a lot!) as a plugin to our library. We would like to be able to use it as a drop-in add-on in the browser as well, but `index.js` assumes Node.js/CommonJS environment.

So I added a UMD wrapper, that simply exposes three functions according to your example. In case of plugin build it shouldn't cause andy side-effects.

I didn't re-build the library to avoid unnecessary diffs, it's better if you do it yourself in the same environment if you decide to accept the changes

Once again, thanks a lot for the great solution.