### PR TITLE
Add GL JS as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "buble": "^0.14.2",
     "uglify-js": "^2.4.10"
   },
+  "peerDependencies": {
+    "mapbox-gl": ">=0.32.1 <2.0.0"
+ },
   "main": "index.js",
   "description": "Add support for RTL languages to mapbox-gl-js."
 }


### PR DESCRIPTION
Add a peer dependency so that npm will ensure the correct version of GL JS is installed alongside the plugin