### PR TITLE
[security] Build script points to an unclaimed s3 bucket.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,11 @@ function download_and_extract {
 
 function setup_emsdk {
 	download_and_extract \
-        https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz \
+				# This is an unclaimed (and potentially malicious) bucket
+				# https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz \
+				# Download the current version of SDK from https://github.com/emscripten-core/emsdk/
+				# As part of re-enabling the build script, verify the package you intend to download
+				# and update the hash.
         emsdk-portable.tgz \
         5524019776723b42ce731f20d9dff91be63c8f50
 


### PR DESCRIPTION
The hash would prevent executing untrusted code, but we want to make sure future maintainers don't get tricked into updating the hash to match an invalid package.

It would be nice to get the build script up and running again with a newer version of emscripten, but we just want to quickly take care of this loose end before we have a chance to forget about it.

cc @mourner @IamGreut @asheemmamoowala 