### PR TITLE
Dropping peer dependency of mapbox-gl-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "buble": "^0.14.2",
     "uglify-js": "^2.4.10"
   },
-  "peerDependencies": {
-    "mapbox-gl": ">=0.32.1 <2.0.0"
-  },
   "main": "index.js",
   "description": "Add support for RTL languages to mapbox-gl-js."
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-rtl-text/issues/27

From https://github.com/mapbox/mapbox-gl-rtl-text/pull/28:

> My suggestion is to simply drop the `peerDependencies` field which has a lot of annoying caveats with little benefit. We do not maintain/support ancient versions before v0.32.1, and we also do not intend to break plugin compatibility in v3.0.0 (if we ever do so, we may revisit later).