### PR TITLE
Fix bug and add test for empty text handling in styled bidirectional processing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ export default (async function () {
         const stringInputPtr = Module._malloc(nDataBytes);
         const paragraphCount = setParagraph(text, stringInputPtr, nDataBytes);
         if (!paragraphCount) {
-            return [{text, styleIndices}];
+            return [[text, styleIndices]];
         }
 
         const mergedParagraphLineBreakPoints = mergeParagraphLineBreakPoints(lineBreakPoints, paragraphCount);

--- a/test.js
+++ b/test.js
@@ -61,3 +61,15 @@ test('Line breaking with styled bidirectional text', () => {
             ['Iskandarīyah', [6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7]]]
     );
 });
+
+test('Empty text with styled bidirectional processing', () => {
+    // This reproduces the bug from maplibre-gl-js issue #6444
+    // When both name and ref are empty, the result should still be a tuple [text, styleIndices]
+    const result = processStyledBidirectionalText('', [], []);
+    assert.ok(Array.isArray(result), 'Result should be an array');
+    assert.equal(result.length, 1, 'Result should have one line');
+    assert.ok(Array.isArray(result[0]), 'First line should be a tuple (array)');
+    assert.equal(result[0].length, 2, 'Tuple should have 2 elements');
+    assert.equal(result[0][0], '', 'Text should be empty string');
+    assert.deepEqual(result[0][1], [], 'Style indices should be empty array');
+});


### PR DESCRIPTION

**Fix return format for `processStyledBidirectionalText` with empty input**

The `processStyledBidirectionalText` function was returning an incorrect format when given empty text. It returned `[{text, styleIndices}]` (an object wrapped in an array) instead of `[[text, styleIndices]]` (a tuple/array wrapped in an array).

This caused issues in maplibre-gl-js when both `name` and `ref` fields were empty (see maplibre/maplibre-gl-js#6444).

**Changes:**
- Fixed line 162 in `src/index.js` to return `[[text, styleIndices]]` 
- Added test case to prevent regression

The fix ensures consistency with the function's documented return type: `Array<[string, Array<number>]>`
